### PR TITLE
Add the first version of tinyms serving module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ package_name = 'tinyms'
 version_tag = '0.1.0'
 pwd = os.path.dirname(os.path.realpath(__file__))
 
+
 def _read_file(filename):
     with open(os.path.join(pwd, filename), encoding='UTF-8') as f:
         return f.read()
@@ -38,6 +39,9 @@ def _write_version(file):
 required_package = [
     'scipy >= 1.5.3',
     'mindspore >= 1.1.0',
+    'opencv-python >= 4.4.0',
+    'requests >= 2.22.0',
+    'flask >= 1.1.1',
     'wheel >= 0.32.0',
     'setuptools >= 40.8.0',
 ]

--- a/tinyms/serving/__init__.py
+++ b/tinyms/serving/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+""".. TinyMS Serving package."""
+from .client import *
+from .server import *
+from .servable import *
+
+__all__ = ["predict", "start", "shutdown"]

--- a/tinyms/serving/__init__.py
+++ b/tinyms/serving/__init__.py
@@ -15,6 +15,5 @@
 """.. TinyMS Serving package."""
 from .client import *
 from .server import *
-from .servable import *
 
-__all__ = ["predict", "start", "shutdown"]
+__all__ = ["list_servables", "predict", "start", "shutdown"]

--- a/tinyms/serving/client/__init__.py
+++ b/tinyms/serving/client/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+from .client import predict
+
+__all__ = ["predict"]

--- a/tinyms/serving/client/__init__.py
+++ b/tinyms/serving/client/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-from .client import predict
+from .client import list_servables, predict
 
-__all__ = ["predict"]
+__all__ = ["list_servables", "predict"]

--- a/tinyms/serving/client/client.py
+++ b/tinyms/serving/client/client.py
@@ -18,19 +18,38 @@ import requests
 from .vision import preprocess as v_preprocess
 
 
-def predict(img_path, servable_path, dataset_name="mnist"):
-    with open(servable_path, 'r') as f:
-        req = json.load(f)
-
-    img_data = v_preprocess(img_path, dataset_name)
-    req['instance'] = {'shape': list(img_data.shape),
-                       'data': json.dumps(img_data.tolist())}
-
+def list_servables():
     headers = {'Content-Type': 'application/json'}
-    url = "http://127.0.0.1:5000/predict"
-    res = requests.post(url=url, headers=headers, data=json.dumps(req))
+    url = "http://127.0.0.1:5000/servables"
+    res = requests.get(url=url, headers=headers)
     res_body = res.json()
     if res.status_code != requests.codes.ok:
+        print("Request error! Status code: ", res.status_code)
+    elif res_body['status'] != 0:
+        print(res_body['err_msg'])
+    else:
+        print(res_body['servables'])
+
+
+def predict(img_path, servable_name, dataset_name="mnist"):
+    # TODO: The preprocess would be moved to data module later
+    img_data = v_preprocess(img_path, dataset_name)
+
+    # Construct the request payload
+    payload = {
+        'instance': {
+            'shape': list(img_data.shape),
+            'data': json.dumps(img_data.tolist())
+        },
+        'servable_name': servable_name
+    }
+    headers = {'Content-Type': 'application/json'}
+    url = "http://127.0.0.1:5000/predict"
+    res = requests.post(url=url, headers=headers, data=json.dumps(payload))
+    res_body = res.json()
+    if res.status_code != requests.codes.ok:
+        print("Request error! Status code: ", res.status_code)
+    elif res_body['status'] != 0:
         print(res_body['err_msg'])
     else:
         print(res_body['instance'])

--- a/tinyms/serving/client/client.py
+++ b/tinyms/serving/client/client.py
@@ -1,0 +1,36 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import json
+import requests
+
+from .vision import preprocess as v_preprocess
+
+
+def predict(img_path, servable_path, dataset_name="mnist"):
+    with open(servable_path, 'r') as f:
+        req = json.load(f)
+
+    img_data = v_preprocess(img_path, dataset_name)
+    req['instance'] = {'shape': list(img_data.shape),
+                       'data': json.dumps(img_data.tolist())}
+
+    headers = {'Content-Type': 'application/json'}
+    url = "http://127.0.0.1:5000/predict"
+    res = requests.post(url=url, headers=headers, data=json.dumps(req))
+    res_body = res.json()
+    if res.status_code != requests.codes.ok:
+        print(res_body['err_msg'])
+    else:
+        print(res_body['instance'])

--- a/tinyms/serving/client/vision.py
+++ b/tinyms/serving/client/vision.py
@@ -1,0 +1,87 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import os
+import sys
+import cv2
+import numpy as np
+from PIL import Image
+
+def _crop_center(img, cropx, cropy):
+    y, x, _ = img.shape
+    startx = x // 2 - (cropx // 2)
+    starty = y // 2 - (cropy // 2)
+    return img[starty:starty + cropy, startx:startx + cropx, :]
+
+
+def _normalize(img, mean, std):
+    # This method is borrowed from:
+    #   https://github.com/open-mmlab/mmcv/blob/master/mmcv/image/photometric.py
+    assert img.dtype != np.uint8
+    mean = np.float64(mean.reshape(1, -1))
+    stdinv = 1 / np.float64(std.reshape(1, -1))
+    cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+    cv2.subtract(img, mean, img)
+    cv2.multiply(img, stdinv, img)
+    return img
+
+
+def _data_preprocess_cifar10(img_data):
+    img = cv2.cvtColor(img_data, cv2.COLOR_RGB2BGR)
+    img = cv2.resize(img, (224, 224))
+    mean = [0.4914 * 255, 0.4822 * 255, 0.4465 * 255]
+    std = [0.2023 * 255, 0.1994 * 255, 0.2010 * 255]
+    img = _normalize(img.astype(np.float32), np.asarray(mean), np.asarray(std))
+    img = img.transpose(2, 0, 1)
+
+    return img
+
+
+def _data_preprocess_imagenet2012(img_data):
+    img = cv2.cvtColor(img_data, cv2.COLOR_RGB2BGR)
+    img = cv2.resize(img, (256, 256))
+    img = _crop_center(img, 224, 224)
+    mean = [0.485 * 255, 0.456 * 255, 0.406 * 255]
+    std = [0.229 * 255, 0.224 * 255, 0.225 * 255]
+    img = _normalize(img.astype(np.float32), np.asarray(mean), np.asarray(std))
+    img = img.transpose(2, 0, 1)
+
+    return img
+
+
+def _data_preprocess_mnist(img_data):
+    img = cv2.cvtColor(img_data, cv2.COLOR_RGB2GRAY)
+    img = cv2.resize(img, (32, 32))
+    img = _crop_center(img, 28, 28)
+
+    return img
+
+
+def preprocess(img_path, dataset_name="mnist"):
+    # check if dataset_name and img_path are valid
+    if dataset_name not in ("mnist", "cifar10", "imagenet2012"):
+        print("Currently dataset_name only supports `mnist`, `cifar10` and `imagenet2012`!")
+        sys.exit(0)
+    if not os.path.isfile(img_path):
+        print("The image path "+img_path+" not exist!")
+        sys.exit(0)
+
+    img = Image.open(img_path)
+    img_data = np.array(img)
+    if dataset_name == "mnist":
+        return _data_preprocess_mnist(img_data)
+    elif dataset_name == "cifar10":
+        return _data_preprocess_cifar10(img_data)
+    else:
+        return _data_preprocess_imagenet2012(img_data)

--- a/tinyms/serving/config/request.json
+++ b/tinyms/serving/config/request.json
@@ -3,11 +3,5 @@
         "shape": [],
         "data": ""
     },
-    "servable": {
-        "name": "resnet50",
-        "model": {
-            "format": "ckpt",
-            "class_num": 9
-        }
-    }
+    "servable_name": "resnet50_mushroom"
 }

--- a/tinyms/serving/config/request.json
+++ b/tinyms/serving/config/request.json
@@ -1,0 +1,13 @@
+{
+    "instance": {
+        "shape": [],
+        "data": ""
+    },
+    "servable": {
+        "name": "resnet50",
+        "model": {
+            "format": "ckpt",
+            "class_num": 9
+        }
+    }
+}

--- a/tinyms/serving/config/response.json
+++ b/tinyms/serving/config/response.json
@@ -1,0 +1,11 @@
+{
+    "status": 0,
+    "instance": {
+        "shape": [
+            1,
+            9
+        ],
+        "data": ""
+    },
+    "err_msg": ""
+}

--- a/tinyms/serving/config/response.json
+++ b/tinyms/serving/config/response.json
@@ -7,5 +7,15 @@
         ],
         "data": ""
     },
+    "servables": [
+        {
+            "name": "resnet50_mushroom",
+            "description": "This servable hosts a ResNet50 model predicting for mushrooms",
+            "model": {
+                "format": "ckpt",
+                "class_num": 9
+            }
+        }
+    ],
     "err_msg": ""
 }

--- a/tinyms/serving/config/servable.json
+++ b/tinyms/serving/config/servable.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "resnet50_mushroom",
+        "description": "This servable hosts a ResNet50 model predicting for mushrooms",
+        "model": {
+            "name": "resnet50",
+            "format": "ckpt",
+            "class_num": 9
+        }
+    }
+]

--- a/tinyms/serving/servable/__init__.py
+++ b/tinyms/serving/servable/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+from .servable import predict
+
+__all__ = ["predict"]

--- a/tinyms/serving/servable/__init__.py
+++ b/tinyms/serving/servable/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-from .servable import predict
+from .servable import servable_search, predict
 
-__all__ = ["predict"]
+__all__ = ["servable_search", "predict"]

--- a/tinyms/serving/servable/model.py
+++ b/tinyms/serving/servable/model.py
@@ -1,0 +1,391 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import numpy as np
+from scipy.stats import truncnorm
+
+import mindspore.nn as nn
+import mindspore.common.dtype as mstype
+from mindspore import Tensor
+from mindspore.ops import operations as P
+from mindspore.ops import functional as F
+from mindspore.common.initializer import Normal
+
+
+class LeNet5(nn.Cell):
+    """
+    Lenet network
+
+    Args:
+        num_class (int): Number of classes. Default: 10.
+        num_channel (int): Number of channels. Default: 1.
+
+    Returns:
+        Tensor, output tensor
+    Examples:
+        >>> LeNet(num_class=10)
+
+    """
+
+    def __init__(self, num_class=10, num_channel=1, include_top=True):
+        super(LeNet5, self).__init__()
+        self.conv1 = nn.Conv2d(num_channel, 6, 5, pad_mode='valid')
+        self.conv2 = nn.Conv2d(6, 16, 5, pad_mode='valid')
+        self.relu = nn.ReLU()
+        self.max_pool2d = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.include_top = include_top
+        if self.include_top:
+            self.flatten = nn.Flatten()
+            self.fc1 = nn.Dense(16 * 5 * 5, 120, weight_init=Normal(0.02))
+            self.fc2 = nn.Dense(120, 84, weight_init=Normal(0.02))
+            self.fc3 = nn.Dense(84, num_class, weight_init=Normal(0.02))
+
+    def construct(self, x):
+        x = self.conv1(x)
+        x = self.relu(x)
+        x = self.max_pool2d(x)
+        x = self.conv2(x)
+        x = self.relu(x)
+        x = self.max_pool2d(x)
+        if not self.include_top:
+            return x
+        x = self.flatten(x)
+        x = self.relu(self.fc1(x))
+        x = self.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+def _conv_variance_scaling_initializer(in_channel, out_channel, kernel_size):
+    fan_in = in_channel * kernel_size * kernel_size
+    scale = 1.0
+    scale /= max(1., fan_in)
+    stddev = (scale ** 0.5) / .87962566103423978
+    mu, sigma = 0, stddev
+    weight = truncnorm(-2, 2, loc=mu, scale=sigma).rvs(out_channel * in_channel * kernel_size * kernel_size)
+    weight = np.reshape(weight, (out_channel, in_channel, kernel_size, kernel_size))
+    return Tensor(weight, dtype=mstype.float32)
+
+
+def _weight_variable(shape, factor=0.01):
+    init_value = np.random.randn(*shape).astype(np.float32) * factor
+    return Tensor(init_value)
+
+
+def _conv3x3(in_channel, out_channel, stride=1, use_se=False):
+    if use_se:
+        weight = _conv_variance_scaling_initializer(in_channel, out_channel, kernel_size=3)
+    else:
+        weight_shape = (out_channel, in_channel, 3, 3)
+        weight = _weight_variable(weight_shape)
+    return nn.Conv2d(in_channel, out_channel,
+                     kernel_size=3, stride=stride, padding=0, pad_mode='same', weight_init=weight)
+
+
+def _conv1x1(in_channel, out_channel, stride=1, use_se=False):
+    if use_se:
+        weight = _conv_variance_scaling_initializer(in_channel, out_channel, kernel_size=1)
+    else:
+        weight_shape = (out_channel, in_channel, 1, 1)
+        weight = _weight_variable(weight_shape)
+    return nn.Conv2d(in_channel, out_channel,
+                     kernel_size=1, stride=stride, padding=0, pad_mode='same', weight_init=weight)
+
+
+def _conv7x7(in_channel, out_channel, stride=1, use_se=False):
+    if use_se:
+        weight = _conv_variance_scaling_initializer(in_channel, out_channel, kernel_size=7)
+    else:
+        weight_shape = (out_channel, in_channel, 7, 7)
+        weight = _weight_variable(weight_shape)
+    return nn.Conv2d(in_channel, out_channel,
+                     kernel_size=7, stride=stride, padding=0, pad_mode='same', weight_init=weight)
+
+
+def _bn(channel):
+    return nn.BatchNorm2d(channel, eps=1e-4, momentum=0.9,
+                          gamma_init=1, beta_init=0, moving_mean_init=0, moving_var_init=1)
+
+
+def _bn_last(channel):
+    return nn.BatchNorm2d(channel, eps=1e-4, momentum=0.9,
+                          gamma_init=0, beta_init=0, moving_mean_init=0, moving_var_init=1)
+
+
+def _fc(in_channel, out_channel, use_se=False):
+    if use_se:
+        weight = np.random.normal(loc=0, scale=0.01, size=out_channel*in_channel)
+        weight = Tensor(np.reshape(weight, (out_channel, in_channel)), dtype=mstype.float32)
+    else:
+        weight_shape = (out_channel, in_channel)
+        weight = _weight_variable(weight_shape)
+    return nn.Dense(in_channel, out_channel, has_bias=True, weight_init=weight, bias_init=0)
+
+
+class ResidualBlock(nn.Cell):
+    """
+    ResNet V1 residual block definition.
+
+    Args:
+        in_channel (int): Input channel.
+        out_channel (int): Output channel.
+        stride (int): Stride size for the first convolutional layer. Default: 1.
+        use_se (bool): enable SE-ResNet50 net. Default: False.
+        se_block(bool): use se block in SE-ResNet50 net. Default: False.
+
+    Returns:
+        Tensor, output tensor.
+
+    Examples:
+        >>> ResidualBlock(3, 256, stride=2)
+    """
+    expansion = 4
+
+    def __init__(self,
+                 in_channel,
+                 out_channel,
+                 stride=1,
+                 use_se=False, se_block=False):
+        super(ResidualBlock, self).__init__()
+        self.stride = stride
+        self.use_se = use_se
+        self.se_block = se_block
+        channel = out_channel // self.expansion
+        self.conv1 = _conv1x1(in_channel, channel, stride=1, use_se=self.use_se)
+        self.bn1 = _bn(channel)
+        if self.use_se and self.stride != 1:
+            self.e2 = nn.SequentialCell([_conv3x3(channel, channel, stride=1, use_se=True), _bn(channel),
+                                         nn.ReLU(), nn.MaxPool2d(kernel_size=2, stride=2, pad_mode='same')])
+        else:
+            self.conv2 = _conv3x3(channel, channel, stride=stride, use_se=self.use_se)
+            self.bn2 = _bn(channel)
+
+        self.conv3 = _conv1x1(channel, out_channel, stride=1, use_se=self.use_se)
+        self.bn3 = _bn_last(out_channel)
+        if self.se_block:
+            self.se_global_pool = P.ReduceMean(keep_dims=False)
+            self.se_dense_0 = _fc(out_channel, int(out_channel/4), use_se=self.use_se)
+            self.se_dense_1 = _fc(int(out_channel/4), out_channel, use_se=self.use_se)
+            self.se_sigmoid = nn.Sigmoid()
+            self.se_mul = P.Mul()
+        self.relu = nn.ReLU()
+
+        self.down_sample = False
+
+        if stride != 1 or in_channel != out_channel:
+            self.down_sample = True
+        self.down_sample_layer = None
+
+        if self.down_sample:
+            if self.use_se:
+                if stride == 1:
+                    self.down_sample_layer = nn.SequentialCell([_conv1x1(in_channel, out_channel,
+                                                                         stride, use_se=self.use_se), _bn(out_channel)])
+                else:
+                    self.down_sample_layer = nn.SequentialCell([nn.MaxPool2d(kernel_size=2, stride=2, pad_mode='same'),
+                                                                _conv1x1(in_channel, out_channel, 1,
+                                                                         use_se=self.use_se), _bn(out_channel)])
+            else:
+                self.down_sample_layer = nn.SequentialCell([_conv1x1(in_channel, out_channel, stride,
+                                                                     use_se=self.use_se), _bn(out_channel)])
+        self.add = P.TensorAdd()
+
+    def construct(self, x):
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+        if self.use_se and self.stride != 1:
+            out = self.e2(out)
+        else:
+            out = self.conv2(out)
+            out = self.bn2(out)
+            out = self.relu(out)
+        out = self.conv3(out)
+        out = self.bn3(out)
+        if self.se_block:
+            out_se = out
+            out = self.se_global_pool(out, (2, 3))
+            out = self.se_dense_0(out)
+            out = self.relu(out)
+            out = self.se_dense_1(out)
+            out = self.se_sigmoid(out)
+            out = F.reshape(out, F.shape(out) + (1, 1))
+            out = self.se_mul(out, out_se)
+
+        if self.down_sample:
+            identity = self.down_sample_layer(identity)
+
+        out = self.add(out, identity)
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Cell):
+    """
+    ResNet architecture.
+
+    Args:
+        block (Cell): Block for network.
+        layer_nums (list): Numbers of block in different layers.
+        in_channels (list): Input channel in each layer.
+        out_channels (list): Output channel in each layer.
+        strides (list):  Stride size in each layer.
+        num_classes (int): The number of classes that the training images are belonging to.
+        use_se (bool): enable SE-ResNet50 net. Default: False.
+        se_block(bool): use se block in SE-ResNet50 net in layer 3 and layer 4. Default: False.
+    Returns:
+        Tensor, output tensor.
+
+    Examples:
+        >>> ResNet(ResidualBlock,
+        >>>        [3, 4, 6, 3],
+        >>>        [64, 256, 512, 1024],
+        >>>        [256, 512, 1024, 2048],
+        >>>        [1, 2, 2, 2],
+        >>>        10)
+    """
+
+    def __init__(self,
+                 block,
+                 layer_nums,
+                 in_channels,
+                 out_channels,
+                 strides,
+                 num_classes,
+                 use_se=False):
+        super(ResNet, self).__init__()
+
+        if not len(layer_nums) == len(in_channels) == len(out_channels) == 4:
+            raise ValueError("the length of layer_num, in_channels, out_channels list must be 4!")
+        self.use_se = use_se
+        self.se_block = False
+        if self.use_se:
+            self.se_block = True
+
+        if self.use_se:
+            self.conv1_0 = _conv3x3(3, 32, stride=2, use_se=self.use_se)
+            self.bn1_0 = _bn(32)
+            self.conv1_1 = _conv3x3(32, 32, stride=1, use_se=self.use_se)
+            self.bn1_1 = _bn(32)
+            self.conv1_2 = _conv3x3(32, 64, stride=1, use_se=self.use_se)
+        else:
+            self.conv1 = _conv7x7(3, 64, stride=2)
+        self.bn1 = _bn(64)
+        self.relu = P.ReLU()
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, pad_mode="same")
+        self.layer1 = self._make_layer(block,
+                                       layer_nums[0],
+                                       in_channel=in_channels[0],
+                                       out_channel=out_channels[0],
+                                       stride=strides[0],
+                                       use_se=self.use_se)
+        self.layer2 = self._make_layer(block,
+                                       layer_nums[1],
+                                       in_channel=in_channels[1],
+                                       out_channel=out_channels[1],
+                                       stride=strides[1],
+                                       use_se=self.use_se)
+        self.layer3 = self._make_layer(block,
+                                       layer_nums[2],
+                                       in_channel=in_channels[2],
+                                       out_channel=out_channels[2],
+                                       stride=strides[2],
+                                       use_se=self.use_se,
+                                       se_block=self.se_block)
+        self.layer4 = self._make_layer(block,
+                                       layer_nums[3],
+                                       in_channel=in_channels[3],
+                                       out_channel=out_channels[3],
+                                       stride=strides[3],
+                                       use_se=self.use_se,
+                                       se_block=self.se_block)
+
+        self.mean = P.ReduceMean(keep_dims=True)
+        self.flatten = nn.Flatten()
+        self.end_point = _fc(out_channels[3], num_classes, use_se=self.use_se)
+
+    def _make_layer(self, block, layer_num, in_channel, out_channel, stride, use_se=False, se_block=False):
+        """
+        Make stage network of ResNet.
+
+        Args:
+            block (Cell): Resnet block.
+            layer_num (int): Layer number.
+            in_channel (int): Input channel.
+            out_channel (int): Output channel.
+            stride (int): Stride size for the first convolutional layer.
+            se_block(bool): use se block in SE-ResNet50 net. Default: False.
+        Returns:
+            SequentialCell, the output layer.
+
+        Examples:
+            >>> _make_layer(ResidualBlock, 3, 128, 256, 2)
+        """
+        layers = []
+
+        resnet_block = block(in_channel, out_channel, stride=stride, use_se=use_se)
+        layers.append(resnet_block)
+        if se_block:
+            for _ in range(1, layer_num - 1):
+                resnet_block = block(out_channel, out_channel, stride=1, use_se=use_se)
+                layers.append(resnet_block)
+            resnet_block = block(out_channel, out_channel, stride=1, use_se=use_se, se_block=se_block)
+            layers.append(resnet_block)
+        else:
+            for _ in range(1, layer_num):
+                resnet_block = block(out_channel, out_channel, stride=1, use_se=use_se)
+                layers.append(resnet_block)
+        return nn.SequentialCell(layers)
+
+    def construct(self, x):
+        if self.use_se:
+            x = self.conv1_0(x)
+            x = self.bn1_0(x)
+            x = self.relu(x)
+            x = self.conv1_1(x)
+            x = self.bn1_1(x)
+            x = self.relu(x)
+            x = self.conv1_2(x)
+        else:
+            x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        c1 = self.maxpool(x)
+
+        c2 = self.layer1(c1)
+        c3 = self.layer2(c2)
+        c4 = self.layer3(c3)
+        c5 = self.layer4(c4)
+
+        out = self.mean(c5, (2, 3))
+        out = self.flatten(out)
+        out = self.end_point(out)
+
+        return out
+
+
+def lenet5(class_num=10):
+    return LeNet5(num_class=class_num)
+
+
+def resnet50(class_num=10):
+    return ResNet(ResidualBlock,
+                  [3, 4, 6, 3],
+                  [64, 256, 512, 1024],
+                  [256, 512, 1024, 2048],
+                  [1, 2, 2, 2],
+                  class_num)

--- a/tinyms/serving/servable/servable.py
+++ b/tinyms/serving/servable/servable.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import os
+import json
+import numpy as np
+import mindspore
+from mindspore import Tensor
+from mindspore.train.serialization import load_checkpoint
+
+from .model import lenet5, resnet50
+
+
+def predict(instance, name="lenet5", model_format="ckpt", class_num=10):
+    # check if servable name is valid
+    if name not in ("lenet5", "resnet50"):
+        err_msg = "Currently model_name only supports `lenet5` and `resnet50`!"
+        return {"status": 1, "err_msg": err_msg}
+    input = np.array(json.loads(instance['data']), dtype='uint8')
+    net = lenet5(class_num=class_num) if name == "lenet5" else resnet50(class_num=class_num)
+    input = input.reshape((1, 1, 28, 28)) if name == "lenet5" else input.reshape((1, 3, 224, 224))
+
+    # check if model_format is valid
+    if model_format not in ("ckpt"):
+        err_msg = "Currently model_format only supports `ckpt`!"
+        return {"status": 1, "err_msg": err_msg}
+    # load checkpoint
+    ckpt_path = os.path.join("ckpt", name+"."+model_format)
+    if not os.path.isfile(ckpt_path):
+        err_msg = "The model path "+ckpt_path+" not exist!"
+        return {"status": 1, "err_msg": err_msg}
+    load_checkpoint(ckpt_path, net=net)
+
+    # execute the network to perform model prediction
+    data = net(Tensor(input, mindspore.float32)).asnumpy()
+    return {"status": 0, "instance": {"shape": data.shape, "data": json.dumps(data.tolist())}}

--- a/tinyms/serving/servable/servable.py
+++ b/tinyms/serving/servable/servable.py
@@ -21,22 +21,52 @@ from mindspore.train.serialization import load_checkpoint
 
 from .model import lenet5, resnet50
 
+servable_path = '/etc/tinyms/serving/servable.json'
 
-def predict(instance, name="lenet5", model_format="ckpt", class_num=10):
-    # check if servable name is valid
-    if name not in ("lenet5", "resnet50"):
+
+def servable_search(name=None):
+    # Check if servable_path existed
+    if not os.path.exists(servable_path):
+        err_msg = "Servable NOT found in "+servable_path
+        return {"status": 1, "err_msg": err_msg}
+
+    with open(servable_path, 'r') as f:
+        servable_list = json.load(f)
+    if name is not None:
+        # check if servable name is valid
+        def servable_exist(name):
+            for servable in servable_list:
+                if name in servable.values():
+                    return servable
+            return None
+        servable = servable_exist(name)
+        if servable is None:
+            err_msg = "Servable name NOT supported!"
+            return {"status": 1, "err_msg": err_msg}
+        else:
+            return {"status": 0, "servables": [servable]}
+    else:
+        return {"status": 0, "servables": servable_list}
+
+
+def predict(instance, servable_name, servable_model):
+    model_name = servable_model['name']
+    model_format = servable_model['format']
+    class_num = servable_model['class_num']
+    # check if servable model name is valid
+    if model_name not in ("lenet5", "resnet50"):
         err_msg = "Currently model_name only supports `lenet5` and `resnet50`!"
         return {"status": 1, "err_msg": err_msg}
     input = np.array(json.loads(instance['data']), dtype='uint8')
-    net = lenet5(class_num=class_num) if name == "lenet5" else resnet50(class_num=class_num)
-    input = input.reshape((1, 1, 28, 28)) if name == "lenet5" else input.reshape((1, 3, 224, 224))
+    net = lenet5(class_num=class_num) if model_name == "lenet5" else resnet50(class_num=class_num)
+    input = input.reshape((1, 1, 28, 28)) if model_name == "lenet5" else input.reshape((1, 3, 224, 224))
 
     # check if model_format is valid
     if model_format not in ("ckpt"):
         err_msg = "Currently model_format only supports `ckpt`!"
         return {"status": 1, "err_msg": err_msg}
     # load checkpoint
-    ckpt_path = os.path.join("ckpt", name+"."+model_format)
+    ckpt_path = os.path.join("/etc/tinyms/serving", servable_name, model_name+"."+model_format)
     if not os.path.isfile(ckpt_path):
         err_msg = "The model path "+ckpt_path+" not exist!"
         return {"status": 1, "err_msg": err_msg}

--- a/tinyms/serving/server/__init__.py
+++ b/tinyms/serving/server/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+from .server import start, shutdown
+
+__all__ = ["start", "shutdown"]

--- a/tinyms/serving/server/server.py
+++ b/tinyms/serving/server/server.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+from flask import request, Flask, jsonify
+from ..servable import predict
+
+app = Flask(__name__)
+
+
+@app.route('/predict', methods=['POST'])
+def predict_server():
+    json_data = request.get_json()
+    instance = json_data['instance']
+    servable = json_data['servable']
+    model = servable['model']
+
+    res = predict(instance, servable['name'], model['format'], model['class_num'])
+    return jsonify(res)
+
+
+def start(host='127.0.0.1', port=5000):
+    app.run(host=host, port=port)
+
+
+def shutdown():
+    func = request.environ.get('werkzeug.server.shutdown')
+    if func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    func()
+    return 'Server shutting down...'

--- a/tinyms/serving/server/server.py
+++ b/tinyms/serving/server/server.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ============================================================================
 from flask import request, Flask, jsonify
-from ..servable import predict
+from ..servable import predict, servable_search
 
 app = Flask(__name__)
 
@@ -22,11 +22,19 @@ app = Flask(__name__)
 def predict_server():
     json_data = request.get_json()
     instance = json_data['instance']
-    servable = json_data['servable']
-    model = servable['model']
+    servable_name = json_data['servable_name']
 
-    res = predict(instance, servable['name'], model['format'], model['class_num'])
+    res = servable_search(servable_name)
+    if res['status'] != 0:
+        return jsonify(res)
+    servable = res['servables'][0]
+    res = predict(instance, servable_name, servable['model'])
     return jsonify(res)
+
+
+@app.route('/servables', methods=['GET'])
+def list_servables():
+    return jsonify(servable_search())
 
 
 def start(host='127.0.0.1', port=5000):


### PR DESCRIPTION
Please **NOTICE** that this is the first verison of TinyMS Serving module implementation, and a lot of changes and design proposal would be added later.

### What have we done?
These jobs below have be targeted by this PR:
* Develop `client` and `server` module beside `serving` module, and expose `start`, `shutdown` and `predict` method to the public
* Design a simple CS communication mechanism by using `requests` and `flask` package
* Design the intial JSON payload when predicting an image from the serving client

### Next step
For the whole serving framework, we still have a lot of work to be finished:
* Move `servable` definition from `client` to `server` module, which means users don't have to specify the detailed information of servable when predicting an image
* We need to design a product-ready CS communication mechanism, possibily relied on [openapi-generator](https://github.com/OpenAPITools/openapi-generator)
* Some unit tests and e2e tests would be added later