### PR TITLE
fix bugs in start_server() add signal catch to terminate subprocess

### DIFF
--- a/tinyms/tutorial/en/LeNet5/TinyMS_LeNet5_tutorial.ipynb
+++ b/tinyms/tutorial/en/LeNet5/TinyMS_LeNet5_tutorial.ipynb
@@ -37,7 +37,6 @@
    "source": [
     "import os\n",
     "import json\n",
-    "import subprocess\n",
     "import tinyms as ts\n",
     "import tinyms.optimizers as opt\n",
     "from tinyms.data import MnistDataset, download_dataset\n",
@@ -270,7 +269,7 @@
     "\n",
     "To restart server, clicke `Kernel` at the top, then click `Restart & Clear Output`\n",
     "\n",
-    "To shutdown server, if using terminal, simply CTRL + C to shutdown serving, if running in Jupyter, click `Kernel` at the top, then click `Shutdown` or run the following code to shutdown server:"
+    "Run the following code to shutdown server:"
    ]
   },
   {

--- a/tinyms/tutorial/en/ResNet50/TinyMS_ResNet50_tutorial.ipynb
+++ b/tinyms/tutorial/en/ResNet50/TinyMS_ResNet50_tutorial.ipynb
@@ -51,7 +51,6 @@
    "source": [
     "import os\n",
     "import json\n",
-    "import subprocess\n",
     "from tinyms.serving import start_server, predict, list_servables, shutdown\n",
     "\n",
     "\n",
@@ -204,9 +203,9 @@
    "source": [
     " ## Shutdown server\n",
     " \n",
-    " To restart and try another checkpoint file, click `Kernel` at the top, then `Restart & Clear Output`, replace the `servable_json` code\n",
+    "To restart and try another checkpoint file, click `Kernel` at the top, then `Restart & Clear Output`, replace the `servable_json` code and `predict()` function\n",
     " \n",
-    " To shutdown server, if using terminal, simply CTRL + C to shutdown serving, if running in Jupyter, click `Kernel` at the top and then `Shutdown`, or run the following code to shutdown server:"
+    "Run the following code to shutdown Flask server:"
    ]
   },
   {

--- a/tinyms/tutorial/zh/LeNet5/TinyMS_LeNet5_tutorial_zh.ipynb
+++ b/tinyms/tutorial/zh/LeNet5/TinyMS_LeNet5_tutorial_zh.ipynb
@@ -37,7 +37,6 @@
    "source": [
     "import os\n",
     "import json\n",
-    "import subprocess\n",
     "import tinyms as ts\n",
     "import tinyms.optimizers as opt\n",
     "from tinyms.data import MnistDataset, download_dataset\n",
@@ -270,7 +269,7 @@
     "\n",
     "重启服务器，点击上方的`Kernel`，再点击`Restart & Clear Output`\n",
     "\n",
-    "关闭服务器，如果使用终端，可以直接CTRL + C关闭，如果使用Jupyter，点击上方`Kernel`，再点击`Shutdown`，或者运行如下代买关闭服务器："
+    "运行以下代码关闭服务器："
    ]
   },
   {

--- a/tinyms/tutorial/zh/ResNet50/TinyMS_ResNet50_tutorial_zh.ipynb
+++ b/tinyms/tutorial/zh/ResNet50/TinyMS_ResNet50_tutorial_zh.ipynb
@@ -51,7 +51,6 @@
    "source": [
     "import os\n",
     "import json\n",
-    "import subprocess\n",
     "from tinyms.serving import start_server, predict, list_servables, shutdown\n",
     "\n",
     "\n",
@@ -206,7 +205,7 @@
     "\n",
     "重启服务器并使用另一种模型，点击左上方`Kernel`，再点击`Restart & Clear Output`，并替换`servable_json`代码段\n",
     "\n",
-    "关闭服务器，如果使用终端，可以直接CTRL + C关闭，如果使用Jupyter，点击上方`Kernel`再点击`Shutdown`，或者运行如下代码段关闭服务器："
+    "关闭服务器，运行下列代码段关闭服务器："
    ]
   },
   {


### PR DESCRIPTION
Now start_server() will detect whether 127.0.0.1:5000 is used or not first, and the signal to keyboard interrupt (CTRL + C) can be catched to terminate the subprocess.

All 4 tutorials are updated as well.