### PR TITLE
Upgrade MindSpore version to v1.2.0 and make some adaptation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 */version.py
 
 **/.DS_Store
+somas_meta/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,13 @@
+numpy >= 1.17.0
 easydict >= 1.9
-scipy >= 1.5.3
-mindspore == 1.2.0
-matplotlib >= 3.1.1
+scipy >= 1.5.2
+matplotlib >= 3.1.3
 Pillow >= 6.2.0
-requests >= 2.22.0
-flask >= 1.1.1
+mindspore == 1.2.0
 wheel >= 0.32.0
 setuptools >= 40.8.0
+requests >= 2.22.0
+flask >= 1.1.1
 python-Levenshtein >= 0.10.2
 gensim >= 3.8.1
+pycocotools >= 2.0.0          # for st test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 easydict >= 1.9
 scipy >= 1.5.3
-mindspore == 1.1.1
+mindspore == 1.2.0
 matplotlib >= 3.1.1
 Pillow >= 6.2.0
 requests >= 2.22.0

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,12 @@ def _write_version(file):
 
 
 required_package = [
+    'numpy >= 1.17.0',
     'easydict >= 1.9',
-    'scipy >= 1.5.3',
-    'mindspore == 1.2.0',
-    'matplotlib >= 3.1.1',
+    'scipy >= 1.5.2',
+    'matplotlib >= 3.1.3',
     'Pillow >= 6.2.0',
+    'mindspore == 1.2.0',
     'requests >= 2.22.0',
     'flask >= 1.1.1',
     'wheel >= 0.32.0',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import os
 import setuptools
 
 package_name = 'tinyms'
-version_tag = '0.1.0'
+version_tag = '0.2.0'
 pwd = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -38,7 +38,7 @@ def _write_version(file):
 required_package = [
     'easydict >= 1.9',
     'scipy >= 1.5.3',
-    'mindspore == 1.1.1',
+    'mindspore == 1.2.0',
     'matplotlib >= 3.1.1',
     'Pillow >= 6.2.0',
     'requests >= 2.22.0',

--- a/tests/ut/model/test_model.py
+++ b/tests/ut/model/test_model.py
@@ -15,7 +15,8 @@
 
 import tinyms as ts
 from tinyms import context, layers
-from tinyms.model import Model, lenet5, resnet50, mobilenetv2, \
+from tinyms.model import Model, lenet5, resnet50, alexnet, densenetBC_100, \
+    mobilenetv2, mobilenetv2_infer, \
     ssd300_mobilenetv2, ssd300_infer
 
 
@@ -51,10 +52,37 @@ def test_resnet50():
     print(z.asnumpy())
 
 
+def test_alexnet():
+    context.set_context(mode=context.GRAPH_MODE, device_target="CPU")
+
+    model = Model(alexnet())
+    model.compile()
+    z = model.predict(ts.ones((1, 3, 224, 224)))
+    print(z.asnumpy())
+
+
+def test_densenetBC_100():
+    context.set_context(mode=context.GRAPH_MODE, device_target="CPU")
+
+    model = Model(densenetBC_100())
+    model.compile()
+    z = model.predict(ts.ones((1, 3, 32, 32)))
+    print(z.asnumpy())
+
+
 def test_mobilenetv2():
     context.set_context(mode=context.GRAPH_MODE, device_target="CPU")
 
     model = Model(mobilenetv2())
+    model.compile()
+    z = model.predict(ts.ones((1, 3, 224, 224)))
+    print(z.asnumpy())
+
+
+def test_mobilenetv2_infer():
+    context.set_context(mode=context.GRAPH_MODE, device_target="CPU")
+
+    model = Model(mobilenetv2_infer())
     model.compile()
     z = model.predict(ts.ones((1, 3, 224, 224)))
     print(z.asnumpy())

--- a/tinyms/layers.py
+++ b/tinyms/layers.py
@@ -17,7 +17,7 @@ Layer module contains pre-defined building blocks or computing units to construc
 
 The high-level components (Layers) used to construct the neural network.
 """
-from mindspore.nn import Cell
+from mindspore.nn import Cell, GraphCell
 from mindspore.nn.layer.container import SequentialCell, CellList
 from mindspore.nn.layer import activation, normalization, conv, lstm, basic, \
     embedding, pooling, math as nn_math, combined
@@ -68,6 +68,22 @@ class Layer(Cell):
         ...
         ...    def construct(self, x):
         ...        return self.relu(x)
+    """
+    pass
+
+
+class GraphLayer(GraphCell):
+    """
+    Base class for running the graph loaded from MindIR.
+
+    This feature is still under development. Currently `GraphLayer` do not support modifying the structure of the
+    diagram, and can only use data that shape and type are the same as the input when exporting the MindIR.
+
+    Args:
+        graph (object): A compiled graph loaded from MindIR.
+
+    Supported Platforms:
+        ``Ascend`` ``GPU`` ``CPU``
     """
     pass
 

--- a/tinyms/model/__init__.py
+++ b/tinyms/model/__init__.py
@@ -15,8 +15,9 @@
 
 from mindspore import Model as _Model
 from mindspore.train.serialization import load_checkpoint as _load_checkpoint, \
-    save_checkpoint as _save_checkpoint, export as _export
+    save_checkpoint as _save_checkpoint, export as _export, load as _load
 
+from ..layers import GraphLayer
 from .lenet5 import lenet5, LeNet
 from .resnet50 import resnet50, ResNet
 from .mobilenetv2 import mobilenetv2, mobilenetv2_infer, MobileNetV2
@@ -29,6 +30,7 @@ from .sentimentnet import sentimentnet, SentimentNet
 
 __all__ = [
     'Model',
+    'load',
     'lenet5', 'LeNet',
     'resnet50', 'ResNet',
     'mobilenetv2', 'mobilenetv2_infer', 'MobileNetV2',
@@ -139,13 +141,12 @@ class Model(_Model):
         """
         return _save_checkpoint(self._network, ckpt_file_name)
 
-    def export(self, *inputs, file_name, file_format='MINDIR', **kwargs):
+    def export(self, inputs, file_name, file_format='MINDIR', **kwargs):
         """
         Export the TinyMS prediction model to a file in the specified format.
 
         Args:
             inputs (Tensor): Inputs of the `net`.
-            file_name (str): File name of the model to be exported.
             file_name (str): File name of the model to be exported.
             file_format (str): MindSpore currently supports `AIR`, `ONNX` and `MINDIR` format for exported model.
                 Default: MINDIR.
@@ -166,5 +167,41 @@ class Model(_Model):
                 - mean: Input data mean. Default: 127.5.
                 - std_dev: Input data variance. Default: 127.5.
         """
-        return _export(self._network, inputs, file_name,
+        return _export(self._network, inputs, file_name=file_name,
                        file_format=file_format, **kwargs)
+
+
+def load(file_name):
+    """
+    Load MindIR graph and return the network with parameters.
+
+    The returned object is wrapperred by a `GraphLayer`. However, there are some limitations to
+    the current use of `GraphLayer`, see class :class:`tinyms.layers.GraphLayer` for more details.
+
+    Args:
+        file_name (str): MindIR file name.
+
+    Returns:
+        GraphLayer instance, a compiled graph with parameters.
+
+    Raises:
+        ValueError: MindIR file is incorrect.
+
+    Examples:
+        >>> import tinyms as ts
+        >>> import tinyms.layers as layers
+        >>> from tinyms.model import Model, load
+        >>>
+        >>> net = layers.Conv2d(1, 1, kernel_size=3)
+        >>> model = Model(net)
+        >>> input = ts.ones([1, 1, 3, 3])
+        >>> model.export(input, "net", file_format="MINDIR")
+        ...
+        >>> net = load("net.mindir")
+        >>> print(net(input))
+        [[[[ 0.02548009  0.04010789  0.03120251]
+           [ 0.00268656  0.02353744  0.03807815]
+           [-0.00896441 -0.00303641  0.01502199]]]]
+    """
+    graph = _load(file_name)
+    return GraphLayer(graph)

--- a/tinyms/serving/server/server.py
+++ b/tinyms/serving/server/server.py
@@ -137,8 +137,8 @@ def run_flask(host='127.0.0.1', port=5000):
     Directly calling this function is not recommended, please use start_server(). Only Error message will be displayed.
 
     Args:
-        host (str): the ip address of the flask server
-        port (int): the port of the server
+        host (str): the ip address of the flask server. Default: '127.0.0.1'.
+        port (int): the port of the server. Default: 5000.
 
     Returns:
         Server Started
@@ -168,7 +168,8 @@ class Server:
     Args:
         host (str): Serving server host ip. Default: '127.0.0.1'.
         port (int): Serving server listen port. Default: 5000.
-        serving_path (str, optional): Set the read path of a service configuration
+        serving_path (str, optional): Set the read path of a service configuration.
+            Default: '/etc/tinyms/serving/'.
 
     Examples:
         >>> from tinyms.serving import Server
@@ -252,7 +253,6 @@ class Server:
         if not self._check_started() is True:
             print('Server already shutdown at host %s, port %d' % (self.host, self.port))
         else:
-            # TODO: Add dynamic host ip and port support
             if os.path.exists('temp.json'):
                 os.remove('temp.json')
             _FlaskServer(self.host, self.port).shutdown()

--- a/tinyms/vision/transforms.py
+++ b/tinyms/vision/transforms.py
@@ -16,12 +16,14 @@
 import numpy as np
 import tinyms as ts
 from PIL import Image
-from tinyms.primitives import Softmax
 
 from . import _transform_ops
 from ._transform_ops import *
 from .utils import ssd_bboxes_encode, ssd_bboxes_filter, jaccard_numpy
+from .. import Tensor
 from ..data import MnistDataset, Cifar10Dataset, ImageFolderDataset, VOCDataset, GeneratorDataset
+from ..primitives import Softmax
+
 
 __all__ = [
     'mnist_transform', 'MnistTransform',
@@ -77,7 +79,7 @@ class DatasetTransform():
             raise ValueError("Strategy should be one of {}, got {}.".format(self.transform_strategy, strategy))
 
         softmax = Softmax()
-        score_list = softmax(ts.array(input)).asnumpy()
+        score_list = softmax(Tensor(input, dtype=ts.float32)).asnumpy()
         if strategy == 'TOP1_CLASS':
             score = max(score_list[0])
             return ('TOP1: ' + str(self.labels[input[0].argmax()]) + ', score: ' + str(format(score, '.20f')))


### PR DESCRIPTION
**What type of PR is this?**

`/kind enhancement`</br>

**What does this PR do / why do we need it**:

This PR is proposed to upgrade the dependency of MindSpore to `v1.2.0`, after that some required modification have been done to make the CI passed.

Besides, this PR has added a new interface `load` in model module to support load MindIR graph directly to perform model inference operation.
```python
>>> import tinyms as ts
>>> import tinyms.layers as layers
>>> from tinyms.model import Model, load
>>>
>>> net = layers.Conv2d(1, 1, kernel_size=3)
>>> model = Model(net)
>>> input = ts.ones([1, 1, 3, 3])
>>> model.export(input, "net", file_format="MINDIR")
...
>>> net = load("net.mindir")
>>> print(net(input))
[[[[ 0.02548009  0.04010789  0.03120251]
    [ 0.00268656  0.02353744  0.03807815]
    [-0.00896441 -0.00303641  0.01502199]]]]
```

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewers**:

